### PR TITLE
Fix moment-js error, search button disabling and select-picker revision

### DIFF
--- a/src/resources/elements/date-picker/date-picker.js
+++ b/src/resources/elements/date-picker/date-picker.js
@@ -37,13 +37,15 @@ const logger = LogManager.getLogger('date-picker');
 @inject(Element, I18N)
 export class DatePicker {
 
+    dateDisplayFormat = 'MM/DD/YYYY';
+
     constructor(element, i18n) {
         this.element = element;
         this.i18n = i18n;
     }
 
     attached() {
-        let self = this;
+        this.dateDisplayFormat = this.i18n.tr('date-picker.format');
 
         this.datepicker = $(this.element).find('.date-wrapper input');
         this.datepicker.datepicker({
@@ -63,17 +65,17 @@ export class DatePicker {
         }).on('changeDate', (event) => {
             let wrapper = $(event.currentTarget).closest('.date-control');
             if( wrapper.hasClass('end-date')) {
-                self.lastChangeEndDate = event.date;
+                this.lastChangeEndDate = event.date;
             } else {
-                self.lastChangeDate = event.date;
+                this.lastChangeDate = event.date;
             }
 
         }).on('hide', (event) => {
             let wrapper = $(event.currentTarget).closest('.date-control');
             if( wrapper.hasClass('end-date')) {
-                self.endValue = self.lastChangeEndDate;
+                this.endValue = this.lastChangeEndDate;
             } else {
-                self.value = self.lastChangeDate;
+                this.value = this.lastChangeDate;
             }
         });
 
@@ -198,7 +200,7 @@ export class DatePicker {
      * @private
      */
     formatDisplay(val) {
-        return val ? moment(val).format(this.i18n.tr('date-picker.format')) : undefined;
+        return val ? (moment(_.isString(val) ? new Date(val) : val).format(this.dateDisplayFormat)) : undefined;
     }
 
     /**

--- a/src/resources/elements/search/search-form.html
+++ b/src/resources/elements/search/search-form.html
@@ -104,7 +104,7 @@
                 </div>
                 <div class="editor-buttons ${(showMinimize === true) ? 'col-sm-6' : 'col-sm-12'}">
                     <button type="button" class="btn btn-sm btn-default ${!loading ? '' : 'disabled'}" click.delegate="reset()">Reset</button>
-                    <button type="button" class="btn btn-sm btn-primary ${!loading ? '' : 'disabled'}" click.delegate="search()">Search</button>
+                    <button type="button" class="btn btn-sm btn-primary ${!loading ? '' : 'disabled'}" click.delegate="search()" disabled.bind="!valid">Search</button>
                 </div>
             </div>
 

--- a/src/resources/elements/select-picker/select-picker.html
+++ b/src/resources/elements/select-picker/select-picker.html
@@ -4,6 +4,6 @@
 
     <select id.bind="id" class="form-control" multiple.bind="multiple">
         <option></option>
-        <option repeat.for="item of items" value.bind="$parent.getBoundValue(item)">${$parent.getBoundText(item)|t}</option>
+        <option repeat.for="item of items" value.bind="getBoundValue(item)">${getBoundText(item)|t}</option>
     </select>
 </template>

--- a/src/resources/elements/stamps/stamp-editor.js
+++ b/src/resources/elements/stamps/stamp-editor.js
@@ -32,7 +32,8 @@ const PreferredValues = [
     {key: 'condition', category: 'stamps', type: Number, model: ['activeCatalogueNumber', 'ownership']},
     {key: 'albumRef', category: 'stamps', type: Number, model: ['ownership']},
     {key: 'sellerRef', category: 'stamps', type: Number, model: ['ownership']},
-    {key: 'grade', category: 'stamps', type: Number, model: ['ownership']}
+    {key: 'grade', category: 'stamps', type: Number, model: ['ownership']},
+    {key: 'CurrencyCode', modelKey: 'code', category: 'currency', type: String, model: ['ownershup']}
 ];
 
 const CACHED_PURCHASED = 'stamp-editor.purchased';
@@ -54,7 +55,7 @@ function createOwnership() {
         id: 0,
         albumRef: -1,
         sellerRef: -1,
-        code: CurrencyCode.USD.keyName,
+        code: undefined,
         purchased: null, //moment(new Date()).format('YYYY-MM-DDT00:00:00Z'),
         pricePaid: 0.0,
         defects: 0,
@@ -151,7 +152,7 @@ export class StampEditorComponent extends EventManaged {
 
     _validateForm() {
         this.invalid = !this.validity.stamp || !this.validity.catalogueNumber;
-        if( !this.duplicateModel.wantList ) {
+        if( this.duplicateModel && !this.duplicateModel.wantList ) {
             this.invalid = this.invalid || !this.validity.ownership;
         }
     }
@@ -299,7 +300,7 @@ export class StampEditorComponent extends EventManaged {
                         if (pref.type === Number) {
                             value = +value;
                         }
-
+                        let modelKey = pref.modelKey ? pref.modelKey : pref.key;
                         if (pref.model) {
                             pref.model.forEach(function (key) {
                                 if (key === "activeCatalogueNumber") {
@@ -307,12 +308,22 @@ export class StampEditorComponent extends EventManaged {
                                 } else if (key === "ownership") {
                                     m = this.ownership;
                                 }
-                                if (m && (pref.type === Number && (m[pref.key] === undefined || (m[pref.key] <= 0) && value > 0))) {
-                                    m[pref.key] = value;
+                                // only update if the current model value is not defined
+                                if( m ) {
+                                    if (pref.type === Number && (m[modelKey] === undefined || (m[modelKey] <= 0) && value > 0)) {
+                                        m[modelKey] = value;
+                                    } else if( m[modelKey] === undefined && value !== undefined) {
+                                        m[modelKey] = value;
+                                    }
                                 }
                             }, this);
-                        } else if (m && (pref.type === Number && (m[pref.key] === undefined || ( m[pref.key] <= 0) && value > 0))) {
-                            m[pref.key] = value;
+                        // only update if the current model value is not defined
+                        } else if (m) {
+                            if (pref.type === Number && (m[modelKey] === undefined || ( m[modelKey] <= 0) && value > 0)) {
+                                m[modelKey] = value;
+                            } else if( m[modelKey] === undefined && value !== undefined) {
+                                m[modelKey] = value;
+                            }
                         } else if (!m) {
                             logger.warn("The stamp model was not defined at the point of preferences initialization.");
                         }


### PR DESCRIPTION
- ensure there is a duplicateModel in the stamp-editor (avoids an
  undefined error condition)
- stamp-editor now respects the CurrencyCode preference for defaults
- validate the model conditions in the search panel on change for
  enablement of the search button (not enabled unless there is a change)
- drastically simplifies the select-picker by separating the value bound
  from the internal select2 value - ie. it is never bound to the template
  directory.
- all select-picker cases appear to be working with some testing on
  creates and edits.
- handle the moment.js issues around date deprecation for string values

Fixes #128
